### PR TITLE
feat(timeline): display job content

### DIFF
--- a/src/components/Timeline.vue
+++ b/src/components/Timeline.vue
@@ -27,7 +27,7 @@
             </div>
           </div>
           <div class="text-sm text-muted-foreground whitespace-nowrap">
-            {{ item.date }}
+            {{ item.duration }}
           </div>
         </div>
       </div>
@@ -36,45 +36,32 @@
 </template>
 
 <script>
+import strapiService from '@/services/strapi'
+
 export default {
   name: 'Timeline',
   data() {
     return {
-      items: [
-        {
-          title: 'Senior Software Engineer',
-          company: 'MoneyMatch Sdn Bhd, Malaysia',
-          date: '2021 - Present',
-          description:
-            'Leading a team of developers to build scalable web applications using modern technologies. Lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam, quod.',
-          tags: [
-            'PHP',
-            'Laravel',
-            'MySQL',
-            'Node.js',
-            'TypeScript',
-            'AWS',
-            'Git',
-            'Docker',
-            'Jira',
-            'Trello',
-            'DynamoDB',
-            'Lambda',
-            'System Design',
-            'Code Review',
-            'Code Refactoring',
-            'SQL Optimization',
-          ],
-        },
-        {
-          title: 'Customer Assistant',
-          company: 'Watsons Malaysua',
-          date: '2017 - 2017',
-          description: 'Bootlick customer unnecessarily but end up getting scolding from them',
-          tags: ['Customer Experience'],
-        },
-      ],
+      items: [],
     }
+  },
+
+  methods: {
+    async fetchJobsData() {
+      try {
+        this.loading = true
+        const response = await strapiService.getJobs()
+        return response.data
+      } catch (error) {
+        this.error = error
+      } finally {
+        this.loading = false
+      }
+    },
+  },
+
+  async mounted() {
+    this.items = await this.fetchJobsData()
   },
 }
 </script>


### PR DESCRIPTION
This change updates the Timeline component to display the job duration instead of the date. The change was made to provide more relevant information to the user, as the duration of a job is more meaningful than the specific date range.

The key changes are:

- Update the `item.date` to `item.duration` in the template
- Fetch the job data from the Strapi service instead of using hardcoded data
- Add error handling and loading state to the component