### PR TITLE
feat(project): Implement dynamic project card rendering

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -8,9 +8,7 @@ import Project from '@/components/Project.vue'
   <div class="min-h-screen p-20 bg-gray-50">
     <div class="max-w-7xl mx-auto space-y-16">
       <Title />
-      <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
-        <Project v-for="n in 3" :key="n" />
-      </div>
+      <Project />
       <Timeline />
     </div>
   </div>

--- a/src/components/Project.vue
+++ b/src/components/Project.vue
@@ -1,45 +1,84 @@
 <template>
-  <div style="transform-style: preserve-3d">
-    <CardContainer>
-      <CardBody
-        class="group/card relative size-auto rounded-xl border border-black/[0.1] bg-gray-50 p-5 sm:w-full dark:border-white/[0.2] dark:bg-black dark:hover:shadow-2xl dark:hover:shadow-emerald-500/[0.1]"
-      >
-        <CardItem :translate-z="50" class="text-lg font-bold text-neutral-600 dark:text-white">
-          Make things float in air
-        </CardItem>
-        <CardItem
-          as="p"
-          translate-z="60"
-          class="mt-2 max-w-sm text-sm text-neutral-500 dark:text-neutral-300"
+  <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+    <div v-for="(item, index) in items" :key="index" style="transform-style: preserve-3d">
+      <CardContainer>
+        <CardBody
+          class="group/card relative size-auto rounded-xl border border-black/[0.1] bg-gray-50 p-5 sm:w-full dark:border-white/[0.2] dark:bg-black dark:hover:shadow-2xl dark:hover:shadow-emerald-500/[0.1]"
         >
-          Hover over this card to unleash the power of CSS perspective
-        </CardItem>
-        <CardItem :translate-z="100" class="mt-3 w-full">
-          <img
-            src="https://images.unsplash.com/photo-1441974231531-c6227db76b6e?q=80&w=2560&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D"
-            height="1000"
-            width="1000"
-            class="h-56 w-full rounded-lg object-cover group-hover/card:shadow-xl"
-            alt="thumbnail"
-          />
-        </CardItem>
-        <div class="mt-6 flex items-center justify-between">
-          <CardItem
-            :translate-z="20"
-            as="a"
-            href="https://github.com/your-username/your-repo"
-            target="_blank"
-            class="rounded-xl px-4 py-2 text-xs font-normal dark:text-white flex items-center gap-2"
-          >
-            <img src="/github-mark.svg" alt="GitHub" class="w-4 h-4" />
-            View on GitHub
+          <CardItem :translate-z="50" class="text-lg font-bold text-neutral-600 dark:text-white">
+            {{ item.title || 'Project Title' }}
           </CardItem>
-        </div>
-      </CardBody>
-    </CardContainer>
+          <CardItem
+            as="p"
+            translate-z="60"
+            class="mt-2 max-w-sm text-sm text-neutral-500 dark:text-neutral-300"
+          >
+            {{ item.description || 'N/A' }}
+          </CardItem>
+          <CardItem :translate-z="100" class="mt-3 w-full">
+            <img
+              v-if="item.image?.url"
+              :src="getImageUrl(item.image)"
+              height="1000"
+              width="1000"
+              class="h-56 w-full rounded-lg object-cover group-hover/card:shadow-xl"
+              :alt="item.title || 'Project thumbnail'"
+            />
+            <div v-else class="h-56 w-full bg-gray-200 rounded-lg flex items-center justify-center">
+              <span class="text-gray-400">No image</span>
+            </div>
+          </CardItem>
+          <div class="mt-6 flex items-center justify-between">
+            <CardItem
+              :translate-z="20"
+              as="a"
+              :href="item.github || '#'"
+              target="__blank"
+              class="px-4 py-2 rounded-xl text-xs font-normal dark:text-white"
+            >
+              View Project →
+            </CardItem>
+          </div>
+        </CardBody>
+      </CardContainer>
+    </div>
   </div>
 </template>
 
 <script setup>
 import { CardContainer, CardBody, CardItem } from '@/components/ui/card-3d'
+</script>
+
+<script>
+import strapiService from '@/services/strapi'
+
+export default {
+  name: 'Project',
+  data() {
+    return {
+      items: [],
+    }
+  },
+
+  methods: {
+    async fetchProjectsData() {
+      try {
+        this.loading = true
+        const response = await strapiService.getProjects()
+        return response.data
+      } catch (error) {
+        this.error = error
+      } finally {
+        this.loading = false
+      }
+    },
+    getImageUrl(media) {
+      return strapiService.getMediaUrl(media)
+    },
+  },
+
+  async mounted() {
+    this.items = await this.fetchProjectsData()
+  },
+}
 </script>


### PR DESCRIPTION
This commit introduces the following changes:

- Refactor the `Project` component to use a dynamic grid layout and fetch project data from the Strapi service.
- Add support for displaying project images, titles, descriptions, and links to the project's GitHub repository.
- Modify the `App` component to use the updated `Project` component.

The main goals of these changes are to:

1. Improve the flexibility and scalability of the project card display by making it dynamic.
2. Integrate with the Strapi service to fetch and display real project data.
3. Enhance the user experience by providing more detailed information about each project.